### PR TITLE
fix: replaced dead coingecko url and fixed APR @ BNB-BUSD

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -25,7 +25,7 @@ const Menu = (props) => {
       setLang={setSelectedLanguage}
       cakePriceUsd={cakePriceUsd.toNumber()}
       links={config}
-      priceLink="https://www.coingecko.com/en/coins/toad-farm"
+      priceLink="https://bscscan.com/token/0x22d67b3f6acdf8c0682f6fb20590e902deea6ba1"
       {...props}
     />
   )

--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -81,7 +81,7 @@ const farms: FarmConfig[] = [
       56: '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c',
     },
     quoteTokenSymbol: QuoteToken.BUSD,
-    quoteTokenAdresses: contracts.wbnb,
+    quoteTokenAdresses: contracts.busd,
   },
 
   {


### PR DESCRIPTION
Hi
I thought, better replace the dead coingecko url with a working url to the blockexplorer.
And I fixed the wrong APR of the BNB-BUSD pair
best regards